### PR TITLE
Add Cloudflare Analytics integration

### DIFF
--- a/CLOUDFLARE_ANALYTICS.md
+++ b/CLOUDFLARE_ANALYTICS.md
@@ -1,0 +1,27 @@
+# Cloudflare Web Analytics
+
+## Setup
+
+Add your token to `_config.yml`:
+```yaml
+analytics:
+  provider: "cloudflare"
+  cloudflare:
+    token: "YOUR_TOKEN_HERE"
+```
+
+Restart Jekyll after config changes: `docker compose restart`
+
+## Implementation
+
+- `_includes/head/custom.html` - Loads beacon script when configured
+- Automatically included on all pages via Minimal Mistakes theme
+
+## Coverage
+
+All page types: home, posts, pages, archives (tags, categories)
+
+## Notes
+
+CORS errors on localhost are expected - works on production.
+

--- a/_config.yml
+++ b/_config.yml
@@ -74,6 +74,12 @@ plugins:
   - jemoji
   - jekyll-include-cache
 
+# Analytics
+analytics:
+  provider: "cloudflare"
+  cloudflare:
+    token: "3d87496e683b4f82894de052683d46b2"  # Replace with your actual token
+
 author:
   name   : "Aman"
   avatar : "/assets/images/bio-photo.jpg"

--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -1,0 +1,5 @@
+<!-- Cloudflare Web Analytics -->
+{% if site.analytics.provider == "cloudflare" and site.analytics.cloudflare.token %}
+<script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "{{ site.analytics.cloudflare.token }}"}'></script>
+{% endif %}
+


### PR DESCRIPTION
- Update `_config.yml` to include Cloudflare analytics configuration.
- Create `CLOUDFLARE_ANALYTICS.md` for setup instructions and implementation details.
- Add `custom.html` to load the Cloudflare beacon script conditionally based on the configuration.

This integration allows for enhanced web analytics tracking across all pages.